### PR TITLE
Adds an upload script for manually downloaded data

### DIFF
--- a/scripts/1_pull_data/manual_pull.py
+++ b/scripts/1_pull_data/manual_pull.py
@@ -45,6 +45,7 @@ def manual_to_aws(domain, datasource, loc):
     path_to_save = aws_datasource_dirs(domain, datasource)
 
     # extract the filename from path
+    loc = loc.replace('\\', '/')
     fname = loc.split('/')[-1]
 
     # point to location of file(s) locally and upload to aws


### PR DESCRIPTION
Many of our datasources will have to be manually uploaded to our AWS bucket - while we could drag and drop, this script helps set up that process. I've set it up that no in-script modifications are needed, and everything can be run from the command line with responses (but happy to modify this further!)

---
To test **(updated by request!):** 
Run `manual_pull.py` and pass the following arguments: domain, datasource, local path to file
Can also do manual_pull.py -h to look at a help overview
For example
```
manual_pull.py built_environment caltrans /Users/victoriaford/Download/FILENAME.zip
```
