### PR TITLE
code to combine storm event loss data 1997-2020

### DIFF
--- a/scripts/data_pull/noaa_storm_event_flooding.ipynb
+++ b/scripts/data_pull/noaa_storm_event_flooding.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "import boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## set-up for AWS  \n",
+    "s3_client = boto3.client('s3')  \n",
+    "bucket_name = 'ca-climate-index'  \n",
+    "directory = '1_pull_data/climate_risk/flood/loss/noaa/downloaded_files'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Path to the main directory containing subfolders and CSV files\n",
+    "main_folder = 'noaa_storm_event_files'\n",
+    "\n",
+    "# Output file to store the filtered and merged data\n",
+    "output_file = 'all_noaa_storm_events_ca.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def merge_and_filter(data_folder, output_file):\n",
+    "    '''\n",
+    "    Iterates through a folder with NOAA's storm event data and filters to the state of California, compiles to a single .csv file, and uploads to AWS bucket.\n",
+    "    Note:\n",
+    "    This function assumes users have configured the AWS CLI such that their access key / secret key pair are stored in ~/.aws/credentials.\n",
+    "    See https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html for guidance.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    folder_path: string\n",
+    "        The folder containing all NOAA storm event CSV files from NOAA's bulk storm event download page: https://www.ncei.noaa.gov/pub/data/swdi/stormevents/csvfiles/\n",
+    "    output_file: string\n",
+    "        Final output as a .csv file.\n",
+    "    '''\n",
+    "\n",
+    "    headers_written = False  # Flag to track if headers have been written to the output file\n",
+    "\n",
+    "    # Create an empty list to hold rows\n",
+    "    rows = []\n",
+    "\n",
+    "    # Iterate through the directory structure\n",
+    "    for root, dirs, files in os.walk(data_folder):\n",
+    "        for file in files:\n",
+    "            # Check if the file is a CSV file\n",
+    "            if file.endswith('.csv'):\n",
+    "                file_path = os.path.join(root, file)\n",
+    "                # Open and read each CSV file\n",
+    "                with open(file_path, 'r', newline='') as infile:\n",
+    "                    reader = csv.reader(infile)\n",
+    "                    # Read the header row from the first file and write it to the output file\n",
+    "                    if not headers_written:\n",
+    "                        headers = next(reader)\n",
+    "                        rows.append(headers)\n",
+    "                        headers_written = True\n",
+    "\n",
+    "                        # Find the index of the column related to 'State'\n",
+    "                        state_index = headers.index('STATE')\n",
+    "\n",
+    "                    # Append rows for California only using the index of the 'State' column\n",
+    "                    for row in reader:\n",
+    "                        if headers_written and row[state_index] == 'CALIFORNIA':  # Filter for California data\n",
+    "                            rows.append(row)\n",
+    "\n",
+    "    # Write the data to a CSV file\n",
+    "    with open(output_file, 'w', newline='') as outfile:\n",
+    "        writer = csv.writer(outfile)\n",
+    "        writer.writerows(rows)\n",
+    "\n",
+    "    # Save the file to AWS S3 using the client\n",
+    "    with open(output_file, 'rb') as data:\n",
+    "        s3_client.upload_fileobj(data, bucket_name, f\"{directory}/{output_file}\")\n",
+    "    print(f\"Merged and sorted files written to {output_file}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Merged and sorted files written to all_noaa_storm_events_ca.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Call the function with the main folder path and output file\n",
+    "merge_and_filter(main_folder, output_file)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "carb",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Extracted all storm event zipped files (by year), placed in a folder, and wrote this script to combine and isolate to CA.

To run:
place .csv files from aws bucket (climate_risk/flood/loss/noaa/downloaded_files) into a folder, and either match the main folder var or update it for your own.