### PR TITLE
cnra protected areas

### DIFF
--- a/scripts/data_metric_calc/governance_protected_areas.ipynb
+++ b/scripts/data_metric_calc/governance_protected_areas.ipynb
@@ -1430,7 +1430,7 @@
    "outputs": [],
    "source": [
     "@append_metadata\n",
-    "def timber_management_upload(input_csv, export=False, varname=''):\n",
+    "def protected_areas_upload(input_csv, export=False, varname=''):\n",
     "    '''\n",
     "    Uploads the protected areas metric to S3 bucket. The metric is:\n",
     "    \n",
@@ -1489,7 +1489,7 @@
     "input_csv = 'governance_cnra_protected_areas_metric.csv'\n",
     "variable = 'governance_cnra_protected_areas'\n",
     "\n",
-    "timber_management_upload(input_csv, varname='test', export=False)"
+    "protected_areas_upload(input_csv, varname='test', export=False)"
    ]
   }
  ],


### PR DESCRIPTION
There is an "acre" column which I used for this first draft. There are also columns GAP1-4 acres which indicate:

 GAP1_acres: 
Acres under GAP Status code 1 reflecting areas managed for biodiversity, where disturbance events proceed or are mimicked.  

GAP2_acres:
Acres under GAP Status code 2 reflecting areas managed for biodiversity, where disturbance events suppressed.

GAP3_acres
Acres under GAP status code 3 reflecting areas managed for multiple uses, subject to extractive (e.g. mining or logging) or OHV use.

GAP4_acres
Areas under GAP status code 4 where areas have no known mandate for protection. 

So alternatively I could total acrage per row for GAP1-3 columns and exclude the GAP4_acres column which dont have required protection?

The current acre column used is the total of the four sub columns.