### PR TITLE
Drought monitor metrics

### DIFF
--- a/scripts/data_metric_calc/climate_drought_exposure.ipynb
+++ b/scripts/data_metric_calc/climate_drought_exposure.ipynb
@@ -988,10 +988,10 @@
     }
    ],
    "source": [
-    "# reformatting to % of total weeks in drought\n",
-    "tot_num_weeks = len(drought_data.loc[(drought_data['County'] == 'Alameda')]) # 1096 weeks\n",
-    "count_drought_data_total['percent_weeks_drought'] = count_drought_data_total['drought_week_count'] / tot_num_weeks\n",
-    "count_drought_data_total.head(5)"
+    "# # reformatting to % of total weeks in drought\n",
+    "# tot_num_weeks = len(drought_data.loc[(drought_data['County'] == 'Alameda')]) # 1096 weeks\n",
+    "# count_drought_data_total['percent_weeks_drought'] = count_drought_data_total['drought_week_count'] / tot_num_weeks\n",
+    "# count_drought_data_total.head(5)"
    ]
   },
   {
@@ -1141,8 +1141,8 @@
     }
    ],
    "source": [
-    "total_weeks_metric = pd.merge(ca_county_tract, count_drought_data_total, on='County', how='left')\n",
-    "total_weeks_metric"
+    "# total_weeks_metric = pd.merge(ca_county_tract, count_drought_data_total, on='County', how='left')\n",
+    "# total_weeks_metric"
    ]
   },
   {
@@ -1703,7 +1703,7 @@
    "outputs": [],
    "source": [
     "# export\n",
-    "total_weeks_metric.to_csv('climate_drought_total_weeks.csv') # done\n",
+    "count_drought_data_total.to_csv('climate_drought_total_weeks.csv') # done\n",
     "coverage_metric.to_csv('climate_drought_coverage_metric.csv') # done"
    ]
   },


### PR DESCRIPTION
NB for 2 out of 3 metrics from the drought monitor:
- Average annual drought % coverage
- percent of total weeks in drought -- refactored from "total number of weeks in drought"
- Average annual drought severity level --> not done; advocating we drop this metric to avoid use of categorical data
   - This one is tricky... We could grab the median/mode of the most common category but in testing I found that it's usually drought category "D1" for all counties which is... not useful; unless we refactor this metric but I think the coverage metrics captures this


Looking for @jesespinoza thoughts on dropping the first metric!